### PR TITLE
Account for clock cycles

### DIFF
--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 extension CPU {
+    typealias ExtraClockCycles = Int
+    
     @discardableResult
-    func setupAddressing(using addressMode: AddressMode) -> UInt8 {
+    func setupAddressing(using addressMode: AddressMode) -> ExtraClockCycles {
         switch addressMode {
         case .imp: imp()
         case .imm: imm()
@@ -24,14 +26,14 @@ private extension CPU {
     /// Implied.
     ///
     /// I'm not sure how to handle this right now. Sometimes the accumulator is read, and sometimes it's an instruction with no parameters.
-    private func imp() -> UInt8 {
+    private func imp() -> ExtraClockCycles {
         0
     }
 
     /// Immediate.
     ///
     /// The next byte will be read as the address from where to read data.
-    private func imm() -> UInt8 {
+    private func imm() -> ExtraClockCycles {
         addressAbsolute = pc
         pc += 1
 
@@ -41,14 +43,14 @@ private extension CPU {
     /// Zero page.
     ///
     /// The value read from 
-    private func zp0() -> UInt8 {
+    private func zp0() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc)).asWord
         pc += 1
         return 0
     }
 
     /// Zero page, with X offset.
-    private func zpx() -> UInt8 {
+    private func zpx() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc) + xReg).asWord
         pc += 1
         addressAbsolute &= 0x00FF
@@ -56,7 +58,7 @@ private extension CPU {
     }
 
     /// Zero page, with Y offset.
-    private func zpy() -> UInt8 {
+    private func zpy() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc) + yReg).asWord
         pc += 1
         addressAbsolute &= 0x00FF
@@ -64,7 +66,7 @@ private extension CPU {
     }
 
     /// Relative.
-    private func rel() -> UInt8 {
+    private func rel() -> ExtraClockCycles {
         addressRelative = readByte(pc).asWord
         pc += 1
 
@@ -78,14 +80,14 @@ private extension CPU {
     }
 
     /// Absolute.
-    private func abs() -> UInt8 {
+    private func abs() -> ExtraClockCycles {
         addressAbsolute = readWord(pc)
         pc += 2
         return 0
     }
 
     /// Absolute, with X offset.
-    private func abx() -> UInt8 {
+    private func abx() -> ExtraClockCycles {
         let lowByte = readByte(pc)
         let highByte = readByte(pc + 1)
         pc += 2
@@ -101,7 +103,7 @@ private extension CPU {
     }
 
     /// Absolute, with Y offset.
-    private func aby() -> UInt8 {
+    private func aby() -> ExtraClockCycles {
         let lowByte = readByte(pc)
         let highByte = readByte(pc + 1)
         pc += 2
@@ -122,7 +124,7 @@ private extension CPU {
     /// The two next bytes form a 16-bit address from where the absolute address should be read from.
     /// Since the corresponding memory adress will only contain a single byte, we need to read `(pointer + 1) | pointer` to get
     /// the absolute address.
-    private func ind() -> UInt8 {
+    private func ind() -> ExtraClockCycles {
         addressAbsolute = readWord(readWord(pc))
         pc += 2
 
@@ -135,7 +137,7 @@ private extension CPU {
     /// The pointer will point to this location, where we'll read the absolute address from:
     ///
     /// `((loc + X + 1) << 8) | (loc + X)`
-    private func izx() -> UInt8 {
+    private func izx() -> ExtraClockCycles {
         let pointer = readByte(pc).asWord + xReg.asWord
         addressAbsolute = readWord(pointer)
         pc += 1
@@ -149,7 +151,7 @@ private extension CPU {
     /// The pointer will point to this location, where we'll read the absolute address from:
     ///
     /// `(((loc + 1) << 8) | loc) + Y`
-    private func izy() -> UInt8 {
+    private func izy() -> ExtraClockCycles {
         let zeroPagePointer = readByte(pc).asWord
         pc += 1
 

--- a/Sources/Swift6502/CPU.swift
+++ b/Sources/Swift6502/CPU.swift
@@ -52,8 +52,12 @@ class CPU {
 
             let opcode = Self.opcodes[Int(opcodeByte)]
 
-            setupAddressing(using: opcode.1)
-            perform(instruction: opcode.0, addressMode: opcode.1)
+            let extraClockCycles = setupAddressing(using: opcode.1)
+            let shouldIncludeExtraClockCycles = perform(instruction: opcode.0, addressMode: opcode.1)
+
+            // Increase clock cycles and add extra cycles, if needed.
+            // Extra cycles usually happens if a page boundry was crossed.
+            clockCycles += opcode.2 + (shouldIncludeExtraClockCycles ? extraClockCycles : 0)
         }
     }
 

--- a/Sources/Swift6502/CPU.swift
+++ b/Sources/Swift6502/CPU.swift
@@ -10,6 +10,7 @@ class CPU {
     var xReg: UInt8 = 0x00
     var yReg: UInt8 = 0x00
     var flags: UInt8 = 0x00
+    var clockCycles: Int = 0
 
     // These are separated, but they can probably be combined into a single variable. Check what's possible.
     // Maybe the `AddressMode` can return an adress instead?


### PR DESCRIPTION
# Why?
The CPU should be able to keep track of how many clock cycles have been used.

The required clock cycles for an instruction is [already present in the tuple](https://github.com/bstien/Swift6502/blob/713330832bfd11f69a26183957568644bb739c14/Sources/Swift6502/CPU%2BOpcodes.swift#L11).

Some opcodes might require an extra cycle, if a page boundry has been crossed when calculating which address to read the value from. The return type for both setting up address modes and perform instructions have been changed to give a better hint about this.

# What?
- Add typealias for return types when setting up address mode and when performing instructions.
- Add property `clockCycles` to `CPU`.
- Increase `clockCycles` as needed when performing an instruction.