### PR TITLE
Split up address mode tests into separate files

### DIFF
--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -49,7 +49,9 @@ private extension CPU {
         return 0
     }
 
-    /// Zero page, with X offset.
+    /// Zero page, with X register offset.
+    ///
+    /// Read a value from zero page, aka the first page (`0x0000` to `0x00FF`)
     private func zpx() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc) &+ xReg).asWord
         pc += 1

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -171,17 +171,15 @@ private extension CPU {
     ///
     /// `(((loc + 1) << 8) | loc) + Y`
     private func izy() -> ExtraClockCycles {
+        // Read address from zero page pointer and add content of Y register.
         let zeroPagePointer = readByte(pc).asWord
+        let addressRead = readWord(zeroPagePointer)
+        addressAbsolute = addressRead &+ yReg.asWord
+
         pc += 1
 
-        // Read address from zero page pointer.
-        let lowByte = readByte(zeroPagePointer)
-        let highByte = readByte(zeroPagePointer + 1)
-
-        addressAbsolute = .createWord(highByte: highByte, lowByte: lowByte) + yReg.asWord
-
         // Check if page boundry was crossed.
-        if addressAbsolute & 0xFF00 != (highByte.asWord << 8) {
+        if !addressRead.isSamePage(as: addressAbsolute) {
             return 1
         }
 

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -108,14 +108,13 @@ private extension CPU {
 
     /// Absolute, with X offset.
     private func abx() -> ExtraClockCycles {
-        let lowByte = readByte(pc)
-        let highByte = readByte(pc + 1)
+        let addressRead = readWord(pc)
         pc += 2
         
-        addressAbsolute = .createWord(highByte: highByte, lowByte: lowByte) + xReg.asWord
+        addressAbsolute = addressRead &+ xReg.asWord
 
         // 1 extra clock cycle is used if page boundry is crossed.
-        if ((addressAbsolute & 0xFF00) != (UInt16(highByte) << 8)) {
+        if !addressRead.isSamePage(as: addressAbsolute) {
             return 1
         }
 

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -32,7 +32,8 @@ private extension CPU {
 
     /// Immediate.
     ///
-    /// The next byte will be read as the address from where to read data.
+    /// The addressing mode will read the next byte as the data.
+    /// This means that the program counter will already be pointing to this address.
     private func imm() -> ExtraClockCycles {
         addressAbsolute = pc
         pc += 1

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -189,15 +189,3 @@ private extension CPU {
         return 0
     }
 }
-
-extension UInt8 {
-    var asWord: UInt16 {
-        UInt16(self)
-    }
-}
-
-extension UInt16 {
-    static func createWord(highByte: UInt8, lowByte: UInt8) -> UInt16 {
-        (highByte.asWord << 8) | lowByte.asWord
-    }
-}

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -43,7 +43,7 @@ private extension CPU {
 
     /// Zero page.
     ///
-    /// The value read from 
+    /// Point a zero page address, aka the first page. `0x0000` to `0x00FF`.
     private func zp0() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc)).asWord
         pc += 1

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -123,14 +123,13 @@ private extension CPU {
 
     /// Absolute, with Y offset.
     private func aby() -> ExtraClockCycles {
-        let lowByte = readByte(pc)
-        let highByte = readByte(pc &+ 1)
+        let addressRead = readWord(pc)
         pc += 2
 
-        addressAbsolute = .createWord(highByte: highByte, lowByte: lowByte) &+ yReg.asWord
+        addressAbsolute = addressRead &+ yReg.asWord
 
         // 1 extra clock cycle is used if page boundry is crossed.
-        if ((addressAbsolute & 0xFF00) != (highByte.asWord << 8)) {
+        if !addressRead.isSamePage(as: addressAbsolute) {
             return 1
         }
 

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -124,10 +124,10 @@ private extension CPU {
     /// Absolute, with Y offset.
     private func aby() -> ExtraClockCycles {
         let lowByte = readByte(pc)
-        let highByte = readByte(pc + 1)
+        let highByte = readByte(pc &+ 1)
         pc += 2
 
-        addressAbsolute = .createWord(highByte: highByte, lowByte: lowByte) + yReg.asWord
+        addressAbsolute = .createWord(highByte: highByte, lowByte: lowByte) &+ yReg.asWord
 
         // 1 extra clock cycle is used if page boundry is crossed.
         if ((addressAbsolute & 0xFF00) != (highByte.asWord << 8)) {

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -56,7 +56,7 @@ private extension CPU {
     private func zpx() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc) &+ xReg).asWord
         pc += 1
-        addressAbsolute &= 0x00FF
+        
         return 0
     }
 
@@ -64,7 +64,7 @@ private extension CPU {
     private func zpy() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc) + yReg).asWord
         pc += 1
-        addressAbsolute &= 0x00FF
+
         return 0
     }
 

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -51,7 +51,7 @@ private extension CPU {
 
     /// Zero page, with X offset.
     private func zpx() -> ExtraClockCycles {
-        addressAbsolute = (readByte(pc) + xReg).asWord
+        addressAbsolute = (readByte(pc) &+ xReg).asWord
         pc += 1
         addressAbsolute &= 0x00FF
         return 0

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -95,9 +95,14 @@ private extension CPU {
     }
 
     /// Absolute.
+    ///
+    /// Will read the two next bytes and form them into an address.
+    /// Little-endian is used, so the first byte will contain the low byte and the second byte the high byte.
+    /// Ex. the byte sequence `0xAA,0xFF` will form the address `0xFFAA`.
     private func abs() -> ExtraClockCycles {
         addressAbsolute = readWord(pc)
         pc += 2
+        
         return 0
     }
 

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -52,7 +52,9 @@ private extension CPU {
 
     /// Zero page, with X register offset.
     ///
-    /// Read a value from zero page, aka the first page (`0x0000` to `0x00FF`)
+    /// Point a zero page address, offset by the value in the X register.
+    /// If the value with offset exceeds `0xFF` the value wraps around, which means we will
+    /// always address an address within zero page.
     private func zpx() -> ExtraClockCycles {
         addressAbsolute = (readByte(pc) &+ xReg).asWord
         pc += 1
@@ -60,9 +62,13 @@ private extension CPU {
         return 0
     }
 
-    /// Zero page, with Y offset.
+    /// Zero page, with Y register offset.
+    ///
+    /// Point a zero page address, offset by the value in the Y register.
+    /// If the value with offset exceeds `0xFF` the value wraps around, which means we will
+    /// always address an address within zero page.
     private func zpy() -> ExtraClockCycles {
-        addressAbsolute = (readByte(pc) + yReg).asWord
+        addressAbsolute = (readByte(pc) &+ yReg).asWord
         pc += 1
 
         return 0

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -75,15 +75,21 @@ private extension CPU {
     }
 
     /// Relative.
+    ///
+    /// Relative addressing allows for a navigating to an address within -128 to +127 of the program counter.
     private func rel() -> ExtraClockCycles {
         addressRelative = readByte(pc).asWord
         pc += 1
 
-        // Relative addressing allows for a navigating to an address within -128 to +127 of `pc`.
         // If the relative offset is negative, we need to flip the bits so a "subtraction" will occur.
         if addressRelative & 0x80 == 0x80 {
             addressRelative |= 0xFF00
         }
+
+        // TODO: Move absolute address calculation here.
+        // This addressing mode will always require 1 extra cycle, but can
+        // require 2 extra if page boundry is crossed.
+        // We should do this here, rather than when performing the instruction.
 
         return 0
     }

--- a/Sources/Swift6502/CPU+AddressModes.swift
+++ b/Sources/Swift6502/CPU+AddressModes.swift
@@ -156,8 +156,9 @@ private extension CPU {
     ///
     /// `((loc + X + 1) << 8) | (loc + X)`
     private func izx() -> ExtraClockCycles {
-        let pointer = readByte(pc).asWord + xReg.asWord
-        addressAbsolute = readWord(pointer)
+        // Make sure we wrap around in zero page, instead of incrementing page.
+        let pointer = readByte(pc) &+ xReg
+        addressAbsolute = readWord(pointer.asWord)
         pc += 1
 
         return 0

--- a/Sources/Swift6502/Extensions/UInt16+Extensions.swift
+++ b/Sources/Swift6502/Extensions/UInt16+Extensions.swift
@@ -8,4 +8,8 @@ extension UInt16 {
     var lowByte: UInt8 {
         UInt8(self & 0xFF)
     }
+
+    static func createWord(highByte: UInt8, lowByte: UInt8) -> UInt16 {
+        (highByte.asWord << 8) | lowByte.asWord
+    }
 }

--- a/Sources/Swift6502/Extensions/UInt16+Extensions.swift
+++ b/Sources/Swift6502/Extensions/UInt16+Extensions.swift
@@ -9,6 +9,10 @@ extension UInt16 {
         UInt8(self & 0xFF)
     }
 
+    func isSamePage(as other: UInt16) -> Bool {
+        highByte == other.highByte
+    }
+
     static func createWord(highByte: UInt8, lowByte: UInt8) -> UInt16 {
         (highByte.asWord << 8) | lowByte.asWord
     }

--- a/Sources/Swift6502/Extensions/UInt8+Extensions.swift
+++ b/Sources/Swift6502/Extensions/UInt8+Extensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension UInt8 {
+    var asWord: UInt16 {
+        UInt16(self)
+    }
+}

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,20 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_imm() {
-        // Set some random bytes in RAM.
-        // IMM defines that the next byte will be read as data, so `programCounter` will be the
-        // actual address used.
-        // `pc` is set to `1`, to emulate that the first byte in the array below is the opcode and
-        // that it has already been read.
-        let cpu = CPU.create(ram: [0xAA, 0xAA])
-
-        cpu.setupAddressing(using: .imm)
-
-        expect(cpu.addressAbsolute) == 0x00
-        expect(cpu.pc) == 0x01
-    }
-
     func test_zp0() {
         let cpu = CPU.create(ram: [0x01, 0x02])
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,26 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_abx() {
-        let cpu = CPU.create(ram: [0xAA, 0xFF, 0x03], xReg: 0x11)
-
-        let extraClockCycles = cpu.setupAddressing(using: .abx)
-
-        expect(cpu.addressAbsolute) == 0xFFBB
-        expect(cpu.pc) == 0x02
-        expect(extraClockCycles) == 0
-    }
-
-    func test_abx_with_page_boundry_crossed() {
-        let cpu = CPU.create(ram: [0xFF, 0x0E, 0x03], xReg: 0x02)
-
-        let extraClockCycles = cpu.setupAddressing(using: .abx)
-
-        expect(cpu.addressAbsolute) == 0x0F01
-        expect(cpu.pc) == 0x02
-        expect(extraClockCycles) == 1
-    }
-    
     func test_aby() {
         let cpu = CPU.create(ram: [0xAA, 0xFF, 0x03], yReg: 0x11)
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,15 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_zp0() {
-        let cpu = CPU.create(ram: [0x01, 0x02])
-
-        cpu.setupAddressing(using: .zp0)
-
-        expect(cpu.addressAbsolute) == 0x01
-        expect(cpu.pc) == 0x01
-    }
-
     func test_zpy() {
         let cpu = CPU.create(ram: [0xAA, 0x02, 0x03], yReg: 0x02)
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,15 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_abs() {
-        let cpu = CPU.create(ram: [0xAA, 0xFF, 0x03])
-
-        cpu.setupAddressing(using: .abs)
-
-        expect(cpu.addressAbsolute) == 0xFFAA
-        expect(cpu.pc) == 0x02
-    }
-
     func test_abx() {
         let cpu = CPU.create(ram: [0xAA, 0xFF, 0x03], xReg: 0x11)
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -26,15 +26,6 @@ class AddressModeTests: XCTestCase {
         expect(cpu.pc) == 0x01
     }
 
-    func test_zpx() {
-        let cpu = CPU.create(ram: [0xAA, 0x02, 0x03], xReg: 0x02)
-
-        cpu.setupAddressing(using: .zpx)
-
-        expect(cpu.addressAbsolute) == 0xAC
-        expect(cpu.pc) == 0x01
-    }
-
     func test_zpy() {
         let cpu = CPU.create(ram: [0xAA, 0x02, 0x03], yReg: 0x02)
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,24 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_rel_with_positive_offset() {
-        let cpu = CPU.create(ram: [0x03])
-
-        cpu.setupAddressing(using: .rel)
-
-        expect(cpu.addressRelative) == 0x03
-        expect(cpu.pc) == 0x01
-    }
-
-    func test_rel_with_negative_offset() {
-        let cpu = CPU.create(ram: [0xFE])
-
-        cpu.setupAddressing(using: .rel)
-
-        expect(cpu.addressRelative) == 0xFFFE
-        expect(cpu.pc) == 0x01
-    }
-
     func test_abs() {
         let cpu = CPU.create(ram: [0xAA, 0xFF, 0x03])
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,26 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_aby() {
-        let cpu = CPU.create(ram: [0xAA, 0xFF, 0x03], yReg: 0x11)
-
-        let extraClockCycles = cpu.setupAddressing(using: .aby)
-
-        expect(cpu.addressAbsolute) == 0xFFBB
-        expect(cpu.pc) == 0x02
-        expect(extraClockCycles) == 0
-    }
-
-    func test_aby_with_page_boundry_crossed() {
-        let cpu = CPU.create(ram: [0xFF, 0x0E, 0x03], yReg: 0x02)
-
-        let extraClockCycles = cpu.setupAddressing(using: .aby)
-
-        expect(cpu.addressAbsolute) == 0x0F01
-        expect(cpu.pc) == 0x02
-        expect(extraClockCycles) == 1
-    }
-
     func test_ind() {
         let cpu = CPU.create(ram: [0x02, 0x00, 0xAA, 0xFF])
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,15 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_ind() {
-        let cpu = CPU.create(ram: [0x02, 0x00, 0xAA, 0xFF])
-
-        cpu.setupAddressing(using: .ind)
-
-        expect(cpu.addressAbsolute) == 0xFFAA
-        expect(cpu.pc) == 0x02
-    }
-
     func test_izx() {
         let cpu = CPU.create(ram: [0x02, 0x00, 0x00, 0x00, 0xAA, 0xFF], xReg: 0x02)
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,15 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_izx() {
-        let cpu = CPU.create(ram: [0x02, 0x00, 0x00, 0x00, 0xAA, 0xFF], xReg: 0x02)
-
-        cpu.setupAddressing(using: .izx)
-
-        expect(cpu.addressAbsolute) == 0xFFAA
-        expect(cpu.pc) == 0x01
-    }
-
     func test_izy() {
         let cpu = CPU.create(ram: [0x02, 0x00, 0xAA, 0xBB], yReg: 0x02)
 

--- a/Tests/Swift6502Tests/AddressModeTests.swift
+++ b/Tests/Swift6502Tests/AddressModeTests.swift
@@ -3,15 +3,6 @@ import XCTest
 import Nimble
 
 class AddressModeTests: XCTestCase {
-    func test_zpy() {
-        let cpu = CPU.create(ram: [0xAA, 0x02, 0x03], yReg: 0x02)
-
-        cpu.setupAddressing(using: .zpy)
-
-        expect(cpu.addressAbsolute) == 0xAC
-        expect(cpu.pc) == 0x01
-    }
-
     func test_rel_with_positive_offset() {
         let cpu = CPU.create(ram: [0x03])
 

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_ABS_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_ABS_Tests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_ABS_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0xAA, 0xFF])
+
+        cpu.setupAddressing(using: .abs)
+
+        expect(cpu.addressAbsolute) == 0xFFAA
+        expect(cpu.pc) == 0x02
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_ABX_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_ABX_Tests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_ABX_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0xAA, 0xFF], xReg: 0x11)
+
+        let extraClockCycles = cpu.setupAddressing(using: .abx)
+
+        expect(cpu.addressAbsolute) == 0xFFBB
+        expect(cpu.pc) == 0x02
+        expect(extraClockCycles) == 0
+    }
+
+    func test_with_page_boundry_crossed() {
+        let cpu = CPU.create(ram: [0xFF, 0x0E], xReg: 0x02)
+
+        let extraClockCycles = cpu.setupAddressing(using: .abx)
+
+        expect(cpu.addressAbsolute) == 0x0F01
+        expect(cpu.pc) == 0x02
+        expect(extraClockCycles) == 1
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_ABY_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_ABY_Tests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_ABY_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0xAA, 0xFF], yReg: 0x11)
+
+        let extraClockCycles = cpu.setupAddressing(using: .aby)
+
+        expect(cpu.addressAbsolute) == 0xFFBB
+        expect(cpu.pc) == 0x02
+        expect(extraClockCycles) == 0
+    }
+
+    func test_with_page_boundry_crossed() {
+        let cpu = CPU.create(ram: [0xFF, 0x0E], yReg: 0x02)
+
+        let extraClockCycles = cpu.setupAddressing(using: .aby)
+
+        expect(cpu.addressAbsolute) == 0x0F01
+        expect(cpu.pc) == 0x02
+        expect(extraClockCycles) == 1
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_IMM_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_IMM_Tests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_IMM_Tests: XCTestCase {
+    func test_simple_example() {
+        // The immediate addressing mode will read the next byte as the data.
+        // This means that the program counter will already be pointing to this address.
+        let cpu = CPU.create(ram: [], pc: 0xAAAA)
+
+        cpu.setupAddressing(using: .imm)
+
+        // Given that the program counter is already
+        expect(cpu.addressAbsolute) == 0xAAAA
+        expect(cpu.pc) == 0xAAAB
+    }
+
+    func test_extra_cycles() {
+        let cpu = CPU.create(ram: [])
+
+        let extraCycles = cpu.setupAddressing(using: .imm)
+
+        expect(extraCycles) == 0
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_IND_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_IND_Tests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_IND_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0x02, 0x00, 0xAA, 0xFF])
+
+        cpu.setupAddressing(using: .ind)
+
+        expect(cpu.addressAbsolute) == 0xFFAA
+        expect(cpu.pc) == 0x02
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_IZX_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_IZX_Tests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_IZX_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0x02, 0x00, 0x00, 0x00, 0xAA, 0xFF], xReg: 0x02)
+
+        cpu.setupAddressing(using: .izx)
+
+        expect(cpu.addressAbsolute) == 0xFFAA
+        expect(cpu.pc) == 0x01
+    }
+
+    func test_it_wraps_around() {
+        let cpu = CPU.create(ram: [0xFF, 0xAA, 0xFF], xReg: 0x02)
+
+        cpu.setupAddressing(using: .izx)
+
+        expect(cpu.addressAbsolute) == 0xFFAA
+        expect(cpu.pc) == 0x01
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_IZY_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_IZY_Tests.swift
@@ -2,8 +2,8 @@ import XCTest
 @testable import Swift6502
 import Nimble
 
-class AddressModeTests: XCTestCase {
-    func test_izy() {
+class AddressMode_IZY_Tests: XCTestCase {
+    func test_simple_example() {
         let cpu = CPU.create(ram: [0x02, 0x00, 0xAA, 0xBB], yReg: 0x02)
 
         let extraClockCycles = cpu.setupAddressing(using: .izy)
@@ -14,11 +14,11 @@ class AddressModeTests: XCTestCase {
     }
 
     func test_izy_with_page_boundry_crossed() {
-        let cpu = CPU.create(ram: [0x02, 0x00, 0xFE, 0xBB], yReg: 0x03)
+        let cpu = CPU.create(ram: [0x02, 0x00, 0xFF, 0xBB], yReg: 0x01)
 
         let extraClockCycles = cpu.setupAddressing(using: .izy)
 
-        expect(cpu.addressAbsolute) == 0xBC01
+        expect(cpu.addressAbsolute) == 0xBC00
         expect(cpu.pc) == 0x01
         expect(extraClockCycles) == 1
     }

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_REL_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_REL_Tests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_REL_Tests: XCTestCase {
+    func test_with_positive_offset() {
+        let cpu = CPU.create(ram: [0x03])
+
+        cpu.setupAddressing(using: .rel)
+
+        expect(cpu.addressRelative) == 0x0003
+        expect(cpu.pc) == 0x01
+    }
+
+    func test_with_negative_offset() {
+        let cpu = CPU.create(ram: [0xFE])
+
+        cpu.setupAddressing(using: .rel)
+
+        expect(cpu.addressRelative) == 0xFFFE
+        expect(cpu.pc) == 0x01
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_ZP0_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_ZP0_Tests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_ZP0_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0xAA])
+
+        cpu.setupAddressing(using: .zp0)
+
+        expect(cpu.addressAbsolute) == 0xAA
+        expect(cpu.pc) == 0x01
+    }
+
+    func test_extra_cycles() {
+        let cpu = CPU.create(ram: [0xAA])
+
+        let extraCycles = cpu.setupAddressing(using: .zp0)
+
+        expect(extraCycles) == 0
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_ZPX_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_ZPX_Tests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_ZPX_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0xAA], xReg: 0x02)
+
+        cpu.setupAddressing(using: .zpx)
+
+        expect(cpu.addressAbsolute) == 0xAC
+        expect(cpu.pc) == 1
+    }
+
+    func test_value_wraps_around() {
+        let cpu = CPU.create(ram: [0xFF], xReg: 0x02)
+
+        cpu.setupAddressing(using: .zpx)
+
+        expect(cpu.addressAbsolute) == 0x01
+        expect(cpu.pc) == 1
+    }
+
+    func test_no_extra_cycles_are_needed_for_wrap_around() {
+        let cpu = CPU.create(ram: [0xFF], xReg: 0x02)
+
+        let extraCycles = cpu.setupAddressing(using: .zpx)
+
+        expect(extraCycles) == 0
+    }
+}

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_ZPY_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_ZPY_Tests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Swift6502
+import Nimble
+
+class AddressMode_ZPY_Tests: XCTestCase {
+    func test_simple_example() {
+        let cpu = CPU.create(ram: [0xAA], yReg: 0x02)
+
+        cpu.setupAddressing(using: .zpy)
+
+        expect(cpu.addressAbsolute) == 0xAC
+        expect(cpu.pc) == 1
+    }
+
+    func test_value_wraps_around() {
+        let cpu = CPU.create(ram: [0xFF], yReg: 0x02)
+
+        cpu.setupAddressing(using: .zpy)
+
+        expect(cpu.addressAbsolute) == 0x01
+        expect(cpu.pc) == 1
+    }
+
+    func test_no_extra_cycles_are_needed_for_wrap_around() {
+        let cpu = CPU.create(ram: [0xFF], yReg: 0x02)
+
+        let extraCycles = cpu.setupAddressing(using: .zpy)
+
+        expect(extraCycles) == 0
+    }
+}


### PR DESCRIPTION
# Why?
The addressing mode tests were not doing anyone any favors of being in the same file.

# What?
- Split up addressing mode tests into separate files.
- Use wrap around when adding values, to avoid overflow exceptions.
- Add method documentation where needed.
- Add method for checking if two `UInt16`s point to the same page.