### PR TITLE
Fix: Move address calculation for relative addressing

### DIFF
--- a/Sources/Swift6502/CPU+Instructions.swift
+++ b/Sources/Swift6502/CPU+Instructions.swift
@@ -139,7 +139,7 @@ private extension CPU {
     // Branch on carry clear.
     func bcc(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if !readFlag(.carry) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -147,7 +147,7 @@ private extension CPU {
     // Branch on carry set.
     func bcs(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if readFlag(.carry) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -155,7 +155,7 @@ private extension CPU {
     // Branch on result zero.
     func beq(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if readFlag(.zero) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -177,7 +177,7 @@ private extension CPU {
     // Branch on result minus.
     func bmi(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if readFlag(.negative) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -185,7 +185,7 @@ private extension CPU {
     // Branch on result not zero.
     func bne(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if !readFlag(.zero) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -193,7 +193,7 @@ private extension CPU {
     // Branch on result plus.
     func bpl(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if !readFlag(.negative) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -221,7 +221,7 @@ private extension CPU {
     // Branch on overflow clear.
     func bvc(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if !readFlag(.overflow) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -229,7 +229,7 @@ private extension CPU {
     // Branch on overflow set.
     func bvs(addressMode: AddressMode) -> ShouldIncludeExtraClockCycles {
         if readFlag(.overflow) {
-            setPcFromRelativeAddress()
+            pc = addressAbsolute
         }
         return false
     }
@@ -664,18 +664,6 @@ private extension CPU {
 // MARK: - Private methods
 
 private extension CPU {
-    func setPcFromRelativeAddress() {
-        // `addressRelative` may be a negative number, so make sure we don't overflow.
-        let result = pc.addingReportingOverflow(addressRelative)
-
-        // If page boundry is crossed, another clock cycle will be used.
-        if result.overflow {
-            // TODO: Increment clock cycles, when/if needed to keep track of this.
-        }
-
-        pc = result.partialValue
-    }
-
     func compareMemoryAgainst(_ value: UInt8) {
         let memory = readByte(addressAbsolute)
 

--- a/Sources/Swift6502/CPU.swift
+++ b/Sources/Swift6502/CPU.swift
@@ -12,10 +12,8 @@ class CPU {
     var flags: UInt8 = 0x00
     var clockCycles: Int = 0
 
-    // These are separated, but they can probably be combined into a single variable. Check what's possible.
-    // Maybe the `AddressMode` can return an adress instead?
+    /// Points to the address where an instruction either reads a value from, or branches to.
     var addressAbsolute: UInt16 = 0x0000
-    var addressRelative: UInt16 = 0x0000
 
     // MARK: - Private properties
 

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_REL_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_REL_Tests.swift
@@ -8,16 +8,16 @@ class AddressMode_REL_Tests: XCTestCase {
 
         cpu.setupAddressing(using: .rel)
 
-        expect(cpu.addressRelative) == 0x0003
+        expect(cpu.addressAbsolute) == 0x0004
         expect(cpu.pc) == 0x01
     }
 
     func test_with_negative_offset() {
-        let cpu = CPU.create(ram: [0xFE])
+        let cpu = CPU.create(ram: [0x80])
 
         cpu.setupAddressing(using: .rel)
 
-        expect(cpu.addressRelative) == 0xFFFE
+        expect(cpu.addressAbsolute) == 0xFF81
         expect(cpu.pc) == 0x01
     }
 }

--- a/Tests/Swift6502Tests/AddressModes/AddressMode_REL_Tests.swift
+++ b/Tests/Swift6502Tests/AddressModes/AddressMode_REL_Tests.swift
@@ -6,10 +6,11 @@ class AddressMode_REL_Tests: XCTestCase {
     func test_with_positive_offset() {
         let cpu = CPU.create(ram: [0x03])
 
-        cpu.setupAddressing(using: .rel)
+        let extraCycles = cpu.setupAddressing(using: .rel)
 
         expect(cpu.addressAbsolute) == 0x0004
         expect(cpu.pc) == 0x01
+        expect(extraCycles) == 1
     }
 
     func test_with_negative_offset() {
@@ -19,5 +20,15 @@ class AddressMode_REL_Tests: XCTestCase {
 
         expect(cpu.addressAbsolute) == 0xFF81
         expect(cpu.pc) == 0x01
+    }
+
+    func test_page_boundry_cross_produces_extra_cycles() {
+        let cpu = CPU.create(ram: [0x80])
+
+        let extraCycles = cpu.setupAddressing(using: .rel)
+
+        expect(cpu.addressAbsolute) == 0xFF81
+        expect(cpu.pc) == 0x01
+        expect(extraCycles) == 2
     }
 }


### PR DESCRIPTION
# Why?
The calculation for relative address calculation happened too late to figure out whether a page boundry would be crossed or not. We need that info when setting up the address mode.

Moving this also means we no longer need the property `addressRelative`, since this was the only usecase for it.

# What?
- Calculate absolute address, given relative addressing, when setting up addressing mode.
- Remove property `addressRelative`.
- Update tests.